### PR TITLE
Add resource ovirt_disk_attachment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
-variable "ovirt_username" {}
 variable "ovirt_url" {}
+variable "ovirt_username" {}
 variable "ovirt_pass" {}
 
 provider "ovirt" {
@@ -21,19 +21,7 @@ resource "ovirt_vm" "joey_vm_1" {
     subnet_mask = "255.255.255.0"
   }
 
-  attached_disks = [{
-    disk_id   = "${ovirt_disk.joey_disk_1.id}"
-    bootable  = "false"
-    interface = "virtio"
-  }]
-
   template = "Blank"
-
-  provisioner "remote-exec" {
-    inline = [
-      "uptime",
-    ]
-  }
 }
 
 resource "ovirt_disk" "joey_disk_1" {
@@ -42,4 +30,23 @@ resource "ovirt_disk" "joey_disk_1" {
   format            = "cow"
   storage_domain_id = "cadbe661-0e35-4fcb-a70d-2b17e2559d9c"
   sparse            = true
+}
+
+resource "ovirt_disk_attachment" "joey_diskattachment_1" {
+  disk_id   = "${ovirt_disk.joey_disk_1.id}"
+  vm_id     = "${ovirt_vm.joey_vm_1.id}"
+  bootable  = "false"
+  interface = "virtio"
+}
+
+output "disk_id" {
+  value = "${ovirt_disk.joey_disk_1.id}"
+}
+
+output "diskattachment_id" {
+  value = "${ovirt_disk_attachment.joey_diskattachment_1.id}"
+}
+
+output "vm_id" {
+  value = "${ovirt_vm.joey_vm_1.id}"
 }

--- a/ovirt/provider.go
+++ b/ovirt/provider.go
@@ -35,8 +35,9 @@ func Provider() terraform.ResourceProvider {
 		},
 		ConfigureFunc: ConfigureProvider,
 		ResourcesMap: map[string]*schema.Resource{
-			"ovirt_vm":   resourceVM(),
-			"ovirt_disk": resourceDisk(),
+			"ovirt_vm":              resourceVM(),
+			"ovirt_disk":            resourceDisk(),
+			"ovirt_disk_attachment": resourceDiskAttachment(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"ovirt_disk": dataSourceDisk(),

--- a/ovirt/resource_disk.go
+++ b/ovirt/resource_disk.go
@@ -15,12 +15,12 @@ func resourceDisk() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceDiskCreate,
 		Read:   resourceDiskRead,
+		Update: resourceDiskUpdate,
 		Delete: resourceDiskDelete,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"format": {
 				Type:     schema.TypeString,
@@ -35,7 +35,6 @@ func resourceDisk() *schema.Resource {
 			"size": {
 				Type:     schema.TypeInt,
 				Required: true,
-				ForceNew: true,
 			},
 			"shareable": {
 				Type:     schema.TypeBool,
@@ -80,6 +79,10 @@ func resourceDiskCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(addResp.MustDisk().MustId())
+	return resourceDiskRead(d, meta)
+}
+
+func resourceDiskUpdate(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 

--- a/ovirt/resource_disk_attachment.go
+++ b/ovirt/resource_disk_attachment.go
@@ -1,0 +1,214 @@
+// Copyright (C) 2017 Battelle Memorial Institute
+// All rights reserved.
+//
+// This software may be modified and distributed under the terms
+// of the BSD-2 license.  See the LICENSE file for details.
+
+package ovirt
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+)
+
+func resourceDiskAttachment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDiskAttachmentCreate,
+		Read:   resourceDiskAttachmentRead,
+		Update: resourceDiskAttachmentUpdate,
+		Delete: resourceDiskAttachmentDelete,
+		Schema: map[string]*schema.Schema{
+			"vm_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"disk_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"active": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"bootable": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"interface": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"logical_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"pass_discard": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"read_only": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"use_scsi_reservation": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func resourceDiskAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+
+	diskID := d.Get("disk_id").(string)
+	diskService := conn.SystemService().DisksService().DiskService(diskID)
+
+	var disk *ovirtsdk4.Disk
+	err := resource.Retry(30*time.Second, func() *resource.RetryError {
+		getDiskResp, err := diskService.Get().Send()
+		if err != nil {
+			return resource.RetryableError(err)
+		}
+		disk = getDiskResp.MustDisk()
+
+		if disk.MustStatus() == ovirtsdk4.DISKSTATUS_LOCKED {
+			return resource.RetryableError(fmt.Errorf("disk is locked, wait for next check"))
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	attachmentBuilder := ovirtsdk4.NewDiskAttachmentBuilder().
+		Disk(disk).
+		Interface(ovirtsdk4.DiskInterface(d.Get("interface").(string))).
+		Bootable(d.Get("bootable").(bool)).
+		Active(d.Get("active").(bool)).
+		ReadOnly(d.Get("read_only").(bool)).
+		UsesScsiReservation(d.Get("use_scsi_reservation").(bool))
+	if logicalName, ok := d.GetOk("logical_name"); ok {
+		attachmentBuilder.LogicalName(logicalName.(string))
+	}
+	if passDiscard, ok := d.GetOkExists("pass_discard"); ok {
+		attachmentBuilder.PassDiscard(passDiscard.(bool))
+	}
+	attachment, err := attachmentBuilder.Build()
+	if err != nil {
+		return err
+	}
+
+	vmID := d.Get("vm_id").(string)
+	addAttachmentResp, err := conn.SystemService().
+		VmsService().
+		VmService(vmID).
+		DiskAttachmentsService().
+		Add().
+		Attachment(attachment).
+		Send()
+	if err != nil {
+		return err
+	}
+
+	_, ok := addAttachmentResp.Attachment()
+	if ok {
+		d.SetId(vmID + ":" + diskID)
+	}
+
+	return resourceDiskAttachmentRead(d, meta)
+}
+
+func resourceDiskAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceDiskAttachmentRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+	// Disk ID is equals to its relevant Disk Attachment ID
+	// Sess: https://github.com/oVirt/ovirt-engine/blob/68753f46f09419ddcdbb632453501273697d1a20/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/DiskAttachmentMapper.java
+	vmID, diskID, err := getVMIDAndDiskID(d, meta)
+	if err != nil {
+		return err
+	}
+	d.Set("vm_id", vmID)
+	d.Set("disk_id", diskID)
+
+	attachmentService := conn.SystemService().
+		VmsService().
+		VmService(vmID).
+		DiskAttachmentsService().AttachmentService(diskID)
+	attachmentResp, err := attachmentService.Get().Send()
+	if err != nil {
+		return err
+	}
+	attachment, ok := attachmentResp.Attachment()
+	if !ok {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("active", attachment.MustActive())
+	d.Set("bootable", attachment.MustBootable())
+	d.Set("interface", attachment.MustInterface())
+	d.Set("read_only", attachment.MustReadOnly())
+	d.Set("use_scsi_reservation", attachment.MustUsesScsiReservation())
+	if logicalName, ok := attachment.LogicalName(); ok {
+		d.Set("logical_name", logicalName)
+	}
+	if passDiscard, ok := attachment.PassDiscard(); ok {
+		d.Set("pass_discard", passDiscard)
+	}
+
+	return nil
+}
+
+func resourceDiskAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+
+	vmID, diskID, err := getVMIDAndDiskID(d, meta)
+	if err != nil {
+		return err
+	}
+
+	vmService := conn.SystemService().VmsService().VmService(vmID)
+
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		vmGetResp, err := vmService.Get().Send()
+		if err != nil {
+			return resource.RetryableError(err)
+		}
+		if vmGetResp.MustVm().MustStatus() != ovirtsdk4.VMSTATUS_DOWN {
+			return resource.RetryableError(fmt.Errorf("The VM attached to is not down"))
+		}
+		return nil
+	})
+
+	_, err = vmService.
+		DiskAttachmentsService().
+		AttachmentService(diskID).
+		Remove().
+		Send()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getVMIDAndDiskID(d *schema.ResourceData, meta interface{}) (string, string, error) {
+	parts := strings.Split(d.Id(), ":")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("Invalid resource id")
+	}
+	return parts[0], parts[1], nil
+}


### PR DESCRIPTION
This PR adds a new resource `ovirt_disk_attachment` which represents a newly generated disk attachment after attaching a disk to a VM. `DiskAttachment` was previously defined by a field named `attached_disks` within resource `ovirt_vm`. It's more intuitive to regard the `DiskAttachment` as independent resource. Since create/update/delete a disk attachment should not change the configurations of `ovirt_vm` and `ovirt_disk` resources. 

Now your configurations of vm/disk/diskattachment may be as below:

```terraform
resource "ovirt_vm" "my_vm" {
  name               = "my_vm_1"
  cluster            = "Default"
  authorized_ssh_key = "${file(pathexpand("~/.ssh/id_rsa.pub"))}"
  template = "Blank"
}

resource "ovirt_disk" "my_disk_1" {
  name              = "my_disk_1"
  size              = 33687091200
  format            = "cow"
  storage_domain_id = "cadbe661-0e35-4fcb-a70d-2b17e2559d9c"
  sparse            = true
}

resource "ovirt_disk_attachment" "my_diskattachment_1" {
  disk_id   = "${ovirt_disk.my_disk_1.id}"
  vm_id     = "${ovirt_vm.my_vm_1.id}"
  bootable  = "false"
  interface = "virtio"
}
```