### PR TITLE
New resource: ovirt_datacenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Prerequisites:
  * Set GOPATH (usually ~/go)
 
 Building/Installing:
+> Refer to github.com/sinokylin/terraform-provider-ovirt for the latest release
 ```
 $ go get github.com/EMSL-MSC/terraform-provider-ovirt
 $ mkdir ~/.terraform.d/plugins
@@ -28,14 +29,16 @@ provider "ovirt" {
   password = "Password"
 }
 ```
-  * Username - (Required) The username to access the oVirt api including the profile used
+  * username - (Required) The username to access the oVirt api including the profile used
   * url - (Required) The url to the api endpoint (usually the ovirt server with a path of /ovirt-engine/api)
   * password - (Required) Password to access the server
 * Resources
   * ovirt_vm
   * ovirt_disk
+  * ovirt_disk_attachment
 * Data Sources
   * ovirt_disk
+  * ovirt_datacenters
 
 Disclaimer
 ---------

--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,13 @@ resource "ovirt_vm" "my_vm_1" {
   cluster            = "Default"
   authorized_ssh_key = "${file(pathexpand("~/.ssh/id_rsa.pub"))}"
 
+  boot_disk = {
+    disk_id      = "${ovirt_disk.my_boot_disk_2.id}"
+    interface    = "virtio"
+    active       = true
+    logical_name = "/dev/sda"
+  }
+
   network_interface {
     label       = "eth0"
     boot_proto  = "static"
@@ -22,6 +29,15 @@ resource "ovirt_vm" "my_vm_1" {
   }
 
   template = "Blank"
+}
+
+resource "ovirt_disk" "my_boot_disk_2" {
+  name              = "my_boot_disk_2"
+  alias             = "my_boot_disk_2"
+  size              = 23687091200
+  format            = "cow"
+  storage_domain_id = "cadbe661-0e35-4fcb-a70d-2b17e2559d9c"
+  sparse            = true
 }
 
 resource "ovirt_disk" "my_disk_1" {
@@ -36,8 +52,16 @@ resource "ovirt_disk" "my_disk_1" {
 resource "ovirt_disk_attachment" "my_diskattachment_1" {
   disk_id   = "${ovirt_disk.my_disk_1.id}"
   vm_id     = "${ovirt_vm.my_vm_1.id}"
-  bootable  = "false"
+  bootable  = false
   interface = "virtio"
+}
+
+data "ovirt_datacenters" "defaultDC" {
+  name = "Default"
+}
+
+output "default_dc_id" {
+  value = "${data.ovirt_datacenters.defaultDC.datacenters.0.id}"
 }
 
 output "disk_id" {

--- a/ovirt/data_source_ovirt_datacenters.go
+++ b/ovirt/data_source_ovirt_datacenters.go
@@ -1,0 +1,91 @@
+// Copyright (C) 2017 Battelle Memorial Institute
+// All rights reserved.
+//
+// This software may be modified and distributed under the terms
+// of the BSD-2 license.  See the LICENSE file for details.
+
+package ovirt
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+)
+
+func dataSourceOvirtDataCenters() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceOvirtDataCentersRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			// Computed
+			"datacenters": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"local": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"quota_mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceOvirtDataCentersRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+
+	dcsResp, err := conn.SystemService().DataCentersService().
+		List().
+		Search(fmt.Sprintf("name=%s", d.Get("name").(string))).
+		Send()
+	if err != nil {
+		return err
+	}
+	dcs, ok := dcsResp.DataCenters()
+	if !ok || len(dcs.Slice()) == 0 {
+		return fmt.Errorf("your query datacenter returned no results, please change your search criteria and try again")
+	}
+
+	return dataCentersDecriptionAttributes(d, dcs.Slice(), meta)
+}
+
+func dataCentersDecriptionAttributes(d *schema.ResourceData, dcs []*ovirtsdk4.DataCenter, meta interface{}) error {
+	var s []map[string]interface{}
+	for _, v := range dcs {
+		mapping := map[string]interface{}{
+			"id":         v.MustId(),
+			"status":     v.MustStatus(),
+			"local":      v.MustLocal(),
+			"quota_mode": v.MustQuotaMode(),
+		}
+		s = append(s, mapping)
+	}
+	d.SetId(resource.UniqueId())
+	if err := d.Set("datacenters", s); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/ovirt/data_source_ovirt_disk.go
+++ b/ovirt/data_source_ovirt_disk.go
@@ -13,9 +13,9 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func dataSourceDisk() *schema.Resource {
+func dataSourceOvirtDisk() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDiskRead,
+		Read: dataSourceOvirtDiskRead,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -45,7 +45,7 @@ func dataSourceDisk() *schema.Resource {
 	}
 }
 
-func dataSourceDiskRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceOvirtDiskRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*ovirtsdk4.Connection)
 
 	listResp, err := conn.SystemService().DisksService().

--- a/ovirt/provider.go
+++ b/ovirt/provider.go
@@ -35,12 +35,13 @@ func Provider() terraform.ResourceProvider {
 		},
 		ConfigureFunc: ConfigureProvider,
 		ResourcesMap: map[string]*schema.Resource{
-			"ovirt_vm":              resourceVM(),
-			"ovirt_disk":            resourceDisk(),
-			"ovirt_disk_attachment": resourceDiskAttachment(),
+			"ovirt_vm":              resourceOvirtVM(),
+			"ovirt_disk":            resourceOvirtDisk(),
+			"ovirt_disk_attachment": resourceOvirtDiskAttachment(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"ovirt_disk": dataSourceDisk(),
+			"ovirt_disk":        dataSourceOvirtDisk(),
+			"ovirt_datacenters": dataSourceOvirtDataCenters(),
 		},
 	}
 }

--- a/ovirt/resource_ovirt_datacenter.go
+++ b/ovirt/resource_ovirt_datacenter.go
@@ -1,0 +1,156 @@
+// Copyright (C) 2017 Battelle Memorial Institute
+// All rights reserved.
+//
+// This software may be modified and distributed under the terms
+// of the BSD-2 license.  See the LICENSE file for details.
+
+package ovirt
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+)
+
+func resourceOvirtDataCenter() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceOvirtDataCenterCreate,
+		Read:   resourceOvirtDataCenterRead,
+		Update: resourceOvirtDataCenterUpdate,
+		Delete: resourceOvirtDataCenterDelete,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+			},
+			// This field identifies whether the datacenter uses local storage
+			"local": {
+				Type:     schema.TypeBool,
+				Required: true,
+				ForceNew: false,
+			},
+		},
+	}
+}
+
+func resourceOvirtDataCenterCreate(d *schema.ResourceData, meta interface{}) error {
+
+	conn := meta.(*ovirtsdk4.Connection)
+	name := d.Get("name").(string)
+	local := d.Get("local").(bool)
+
+	//Name and Local are required when create a datacenter
+	datacenterbuilder := ovirtsdk4.NewDataCenterBuilder().Name(name).Local(local)
+
+	// Check if has description
+	_, ok := d.GetOkExists("description")
+	if ok {
+		description := d.Get("description").(string)
+		datacenterbuilder = datacenterbuilder.Description(description)
+	}
+
+	datacenter, err := datacenterbuilder.Build()
+	if err != nil {
+		return err
+	}
+
+	addResp, err := conn.SystemService().DataCentersService().Add().DataCenter(datacenter).Send()
+	if err != nil {
+		return err
+	}
+
+	d.SetId(addResp.MustDataCenter().MustId())
+	return resourceOvirtDataCenterRead(d, meta)
+
+}
+
+func resourceOvirtDataCenterUpdate(d *schema.ResourceData, meta interface{}) error {
+
+	var ok bool
+	conn := meta.(*ovirtsdk4.Connection)
+	datacenterService := conn.SystemService().DataCentersService().DataCenterService(d.Id())
+	datacenterBuilder := ovirtsdk4.NewDataCenterBuilder()
+
+    _, ok = d.GetOkExists("name")
+    if ok {
+		if d.HasChange("name") {
+			name := d.Get("name").(string)
+			datacenterBuilder.Name(name)
+		}
+	}else{
+		return fmt.Errorf("DataCenter's name don't not exist!")
+	}
+
+	_, ok = d.GetOkExists("description")
+	if ok && d.HasChange("description") {
+		description := d.Get("description").(string)
+		datacenterBuilder.Description(description)
+	}
+
+    _, ok = d.GetOkExists("local")
+    if ok {
+		if d.HasChange("local") {
+			local := d.Get("local").(bool)
+			datacenterBuilder.Local(local)
+		}
+	}else{
+		return fmt.Errorf("DataCenter's local don't not exist!")
+	}
+
+	datacenter, err := datacenterBuilder.Build()
+	if err != nil {
+		return err
+	}
+
+	_, err = datacenterService.Update().DataCenter(datacenter).Send()
+
+	if err != nil {
+		return err
+	}
+
+	return resourceOvirtDataCenterRead(d, meta)
+}
+
+func resourceOvirtDataCenterRead(d *schema.ResourceData, meta interface{}) error {
+
+	conn := meta.(*ovirtsdk4.Connection)
+	getDataCenterResp, err := conn.SystemService().DataCentersService().
+		DataCenterService(d.Id()).Get().Send()
+	if err != nil {
+		return err
+	}
+
+	datacenter, ok := getDataCenterResp.DataCenter()
+	if !ok {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", datacenter.MustName())
+	d.Set("local", datacenter.MustLocal())
+
+	description, ok := datacenter.Description()
+	if ok {
+		d.Set("description", description)
+	}
+
+	return nil
+}
+
+func resourceOvirtDataCenterDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+
+	_, err := conn.SystemService().DataCentersService().
+		DataCenterService(d.Id()).Remove().Send()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/ovirt/resource_ovirt_disk.go
+++ b/ovirt/resource_ovirt_disk.go
@@ -13,12 +13,12 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func resourceDisk() *schema.Resource {
+func resourceOvirtDisk() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDiskCreate,
-		Read:   resourceDiskRead,
-		Update: resourceDiskUpdate,
-		Delete: resourceDiskDelete,
+		Create: resourceOvirtDiskCreate,
+		Read:   resourceOvirtDiskRead,
+		Update: resourceOvirtDiskUpdate,
+		Delete: resourceOvirtDiskDelete,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -58,7 +58,7 @@ func resourceDisk() *schema.Resource {
 	}
 }
 
-func resourceDiskCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceOvirtDiskCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*ovirtsdk4.Connection)
 
 	diskBuilder := ovirtsdk4.NewDiskBuilder().
@@ -89,10 +89,10 @@ func resourceDiskCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(addResp.MustDisk().MustId())
-	return resourceDiskRead(d, meta)
+	return resourceOvirtDiskRead(d, meta)
 }
 
-func resourceDiskUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceOvirtDiskUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*ovirtsdk4.Connection)
 	diskService := conn.SystemService().
 		DisksService().
@@ -162,7 +162,7 @@ func resourceDiskUpdate(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceDiskRead(d *schema.ResourceData, meta interface{}) error {
+func resourceOvirtDiskRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*ovirtsdk4.Connection)
 	getDiskResp, err := conn.SystemService().DisksService().
 		DiskService(d.Id()).Get().Send()
@@ -197,7 +197,7 @@ func resourceDiskRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceDiskDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceOvirtDiskDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*ovirtsdk4.Connection)
 
 	_, err := conn.SystemService().DisksService().

--- a/ovirt/resource_ovirt_disk_attachment.go
+++ b/ovirt/resource_ovirt_disk_attachment.go
@@ -16,12 +16,12 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func resourceDiskAttachment() *schema.Resource {
+func resourceOvirtDiskAttachment() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDiskAttachmentCreate,
-		Read:   resourceDiskAttachmentRead,
-		Update: resourceDiskAttachmentUpdate,
-		Delete: resourceDiskAttachmentDelete,
+		Create: resourceOvirtDiskAttachmentCreate,
+		Read:   resourceOvirtDiskAttachmentRead,
+		Update: resourceOvirtDiskAttachmentUpdate,
+		Delete: resourceOvirtDiskAttachmentDelete,
 		Schema: map[string]*schema.Schema{
 			"vm_id": &schema.Schema{
 				Type:     schema.TypeString,
@@ -69,7 +69,7 @@ func resourceDiskAttachment() *schema.Resource {
 	}
 }
 
-func resourceDiskAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceOvirtDiskAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*ovirtsdk4.Connection)
 
 	diskID := d.Get("disk_id").(string)
@@ -127,14 +127,14 @@ func resourceDiskAttachmentCreate(d *schema.ResourceData, meta interface{}) erro
 		d.SetId(vmID + ":" + diskID)
 	}
 
-	return resourceDiskAttachmentRead(d, meta)
+	return resourceOvirtDiskAttachmentRead(d, meta)
 }
 
-func resourceDiskAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceOvirtDiskAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceDiskAttachmentRead(d *schema.ResourceData, meta interface{}) error {
+func resourceOvirtDiskAttachmentRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*ovirtsdk4.Connection)
 	// Disk ID is equals to its relevant Disk Attachment ID
 	// Sess: https://github.com/oVirt/ovirt-engine/blob/68753f46f09419ddcdbb632453501273697d1a20/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/DiskAttachmentMapper.java
@@ -174,7 +174,7 @@ func resourceDiskAttachmentRead(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func resourceDiskAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceOvirtDiskAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*ovirtsdk4.Connection)
 
 	vmID, diskID, err := getVMIDAndDiskID(d, meta)

--- a/ovirt/resource_ovirt_vm.go
+++ b/ovirt/resource_ovirt_vm.go
@@ -15,12 +15,12 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func resourceVM() *schema.Resource {
+func resourceOvirtVM() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceVMCreate,
-		Read:   resourceVMRead,
-		Update: resourceVMUpdate,
-		Delete: resourceVMDelete,
+		Create: resourceOvirtVMCreate,
+		Read:   resourceOvirtVMRead,
+		Update: resourceOvirtVMUpdate,
+		Delete: resourceOvirtVMDelete,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -97,7 +97,7 @@ func resourceVM() *schema.Resource {
 	}
 }
 
-func resourceVMCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceOvirtVMCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*ovirtsdk4.Connection)
 	vmsService := conn.SystemService().VmsService()
 
@@ -169,14 +169,14 @@ func resourceVMCreate(d *schema.ResourceData, meta interface{}) error {
 		d.SetId(newVM.MustId())
 	}
 
-	return resourceVMRead(d, meta)
+	return resourceOvirtVMRead(d, meta)
 }
 
-func resourceVMUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceOvirtVMUpdate(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceVMRead(d *schema.ResourceData, meta interface{}) error {
+func resourceOvirtVMRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*ovirtsdk4.Connection)
 
 	getVmresp, err := conn.SystemService().VmsService().
@@ -211,7 +211,7 @@ func resourceVMRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceVMDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceOvirtVMDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*ovirtsdk4.Connection)
 
 	vmService := conn.SystemService().VmsService().VmService(d.Id())


### PR DESCRIPTION
Use the golang sdk of ovirt-engine v4.x to refactor the provider and existing resources/datacenter.

I tested OK with terraform apply and terraform destroy in my local oVirt-v4.2 dev environment,

Notice: Now We just covered the normal deletion of datacenters and did not cover the forced deletion of data centers. This will be fixed soon.