### PR TITLE
Add new datasource: datacenters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,13 @@ resource "ovirt_vm" "my_vm_1" {
   cluster            = "Default"
   authorized_ssh_key = "${file(pathexpand("~/.ssh/id_rsa.pub"))}"
 
+  boot_disk = {
+    disk_id      = "${ovirt_disk.my_boot_disk_2.id}"
+    interface    = "virtio"
+    active       = true
+    logical_name = "/dev/sda"
+  }
+
   network_interface {
     label       = "eth0"
     boot_proto  = "static"
@@ -22,6 +29,15 @@ resource "ovirt_vm" "my_vm_1" {
   }
 
   template = "Blank"
+}
+
+resource "ovirt_disk" "my_boot_disk_2" {
+  name              = "my_boot_disk_2"
+  alias             = "my_boot_disk_2"
+  size              = 23687091200
+  format            = "cow"
+  storage_domain_id = "cadbe661-0e35-4fcb-a70d-2b17e2559d9c"
+  sparse            = true
 }
 
 resource "ovirt_disk" "my_disk_1" {
@@ -36,8 +52,16 @@ resource "ovirt_disk" "my_disk_1" {
 resource "ovirt_disk_attachment" "my_diskattachment_1" {
   disk_id   = "${ovirt_disk.my_disk_1.id}"
   vm_id     = "${ovirt_vm.my_vm_1.id}"
-  bootable  = "false"
+  bootable  = false
   interface = "virtio"
+}
+
+data "ovirt_datacenters" "defaultDC" {
+  name = "Default"
+}
+
+output "default_dc_id" {
+  value = "${data.ovirt_datacenters.defaultDC.datacenters.0.id}"
 }
 
 output "disk_id" {

--- a/ovirt/data_source_datacenters.go
+++ b/ovirt/data_source_datacenters.go
@@ -1,0 +1,91 @@
+// Copyright (C) 2017 Battelle Memorial Institute
+// All rights reserved.
+//
+// This software may be modified and distributed under the terms
+// of the BSD-2 license.  See the LICENSE file for details.
+
+package ovirt
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+)
+
+func dataSourceOvirtDataCenters() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceOvirtDataCentersRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			// Computed
+			"datacenters": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"local": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"quota_mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceOvirtDataCentersRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+
+	dcsResp, err := conn.SystemService().DataCentersService().
+		List().
+		Search(fmt.Sprintf("name=%s", d.Get("name").(string))).
+		Send()
+	if err != nil {
+		return err
+	}
+	dcs, ok := dcsResp.DataCenters()
+	if !ok || len(dcs.Slice()) == 0 {
+		return fmt.Errorf("your query datacenter returned no results, please change your search criteria and try again")
+	}
+
+	return dataCentersDecriptionAttributes(d, dcs.Slice(), meta)
+}
+
+func dataCentersDecriptionAttributes(d *schema.ResourceData, dcs []*ovirtsdk4.DataCenter, meta interface{}) error {
+	var s []map[string]interface{}
+	for _, v := range dcs {
+		mapping := map[string]interface{}{
+			"id":         v.MustId(),
+			"status":     v.MustStatus(),
+			"local":      v.MustLocal(),
+			"quota_mode": v.MustQuotaMode(),
+		}
+		s = append(s, mapping)
+	}
+	d.SetId(resource.UniqueId())
+	if err := d.Set("datacenters", s); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/ovirt/provider.go
+++ b/ovirt/provider.go
@@ -40,7 +40,8 @@ func Provider() terraform.ResourceProvider {
 			"ovirt_disk_attachment": resourceDiskAttachment(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"ovirt_disk": dataSourceDisk(),
+			"ovirt_disk":        dataSourceDisk(),
+			"ovirt_datacenters": dataSourceOvirtDataCenters(),
 		},
 	}
 }


### PR DESCRIPTION
This pr is for implementing the new `ovirt_datacenters` data source. We could get a list of `datacenter` instances by the `name` argument. Currently the returned attributes includes only the `id`, `stats`, `local` and `quota_mode`.