### PR TITLE
Add support for datacenter and network

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,12 +13,12 @@ resource "ovirt_vm" "my_vm_1" {
   cluster            = "Default"
   authorized_ssh_key = "${file(pathexpand("~/.ssh/id_rsa.pub"))}"
 
-#  boot_disk = {
-#    disk_id      = "${ovirt_disk.my_boot_disk_2.id}"
-#    interface    = "virtio"
-#    active       = true
-#    logical_name = "/dev/sda"
-#  }
+  #  boot_disk = {
+  #    disk_id      = "${ovirt_disk.my_boot_disk_2.id}"
+  #    interface    = "virtio"
+  #    active       = true
+  #    logical_name = "/dev/sda"
+  #  }
 
   network_interface {
     label       = "eth0"
@@ -27,7 +27,6 @@ resource "ovirt_vm" "my_vm_1" {
     gateway     = "130.20.232.1"
     subnet_mask = "255.255.255.0"
   }
-
   template = "Blank"
 }
 
@@ -56,8 +55,21 @@ resource "ovirt_disk_attachment" "my_diskattachment_1" {
   interface = "virtio"
 }
 
+resource "ovirt_datacenter" "my_datacenter_1" {
+  name        = "my_datacenter_1"
+  description = "Datacenter Test1"
+  local       = false
+}
+
+resource "ovirt_network" "my_network_1" {
+  name          = "my_network_1"
+  description   = "Network Test1"
+  mtu           = 1001
+  datacenter_id = "${ovirt_datacenter.my_datacenter_1.id}"
+}
+
 data "ovirt_datacenters" "defaultDC" {
-  name = "Default"
+  name = "DefaultMy"
 }
 
 output "default_dc_id" {
@@ -74,4 +86,12 @@ output "diskattachment_id" {
 
 output "vm_id" {
   value = "${ovirt_vm.my_vm_1.id}"
+}
+
+output "datacenter_id" {
+  value = "${ovirt_datacenter.my_datacenter_1.id}"
+}
+
+output "network_id" {
+  value = "${ovirt_network.my_network_1.id}"
 }

--- a/ovirt/provider.go
+++ b/ovirt/provider.go
@@ -38,6 +38,8 @@ func Provider() terraform.ResourceProvider {
 			"ovirt_vm":              resourceOvirtVM(),
 			"ovirt_disk":            resourceOvirtDisk(),
 			"ovirt_disk_attachment": resourceOvirtDiskAttachment(),
+			"ovirt_datacenter":      resourceOvirtDataCenter(),
+			"ovirt_network":         resourceOvirtNetwork(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"ovirt_disk":        dataSourceOvirtDisk(),

--- a/ovirt/resource_ovirt_datacenter.go
+++ b/ovirt/resource_ovirt_datacenter.go
@@ -1,0 +1,146 @@
+// Copyright (C) 2017 Battelle Memorial Institute
+// All rights reserved.
+//
+// This software may be modified and distributed under the terms
+// of the BSD-2 license.  See the LICENSE file for details.
+
+package ovirt
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+)
+
+func resourceOvirtDataCenter() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceOvirtDataCenterCreate,
+		Read:   resourceOvirtDataCenterRead,
+		Update: resourceOvirtDataCenterUpdate,
+		Delete: resourceOvirtDataCenterDelete,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+			},
+			// This field identifies whether the datacenter uses local storage
+			"local": {
+				Type:     schema.TypeBool,
+				Required: true,
+				ForceNew: false,
+			},
+		},
+	}
+}
+
+func resourceOvirtDataCenterCreate(d *schema.ResourceData, meta interface{}) error {
+
+	conn := meta.(*ovirtsdk4.Connection)
+	name := d.Get("name").(string)
+	local := d.Get("local").(bool)
+
+	//Name and Local are required when create a datacenter
+	datacenterbuilder := ovirtsdk4.NewDataCenterBuilder().Name(name).Local(local)
+
+	// Check if has description
+	if description, ok := d.GetOkExists("description"); ok {
+		datacenterbuilder = datacenterbuilder.Description(description.(string))
+	}
+
+	datacenter, err := datacenterbuilder.Build()
+	if err != nil {
+		return err
+	}
+
+	addResp, err := conn.SystemService().DataCentersService().Add().DataCenter(datacenter).Send()
+	if err != nil {
+		return err
+	}
+
+	d.SetId(addResp.MustDataCenter().MustId())
+	return resourceOvirtDataCenterRead(d, meta)
+
+}
+
+func resourceOvirtDataCenterUpdate(d *schema.ResourceData, meta interface{}) error {
+
+	conn := meta.(*ovirtsdk4.Connection)
+	datacenterService := conn.SystemService().DataCentersService().DataCenterService(d.Id())
+	datacenterBuilder := ovirtsdk4.NewDataCenterBuilder()
+
+	if name, ok := d.GetOkExists("name"); ok {
+		if d.HasChange("name") {
+			datacenterBuilder.Name(name.(string))
+		}
+	} else {
+		return fmt.Errorf("DataCenter's name does not exist!")
+	}
+
+	if description, ok := d.GetOkExists("description"); ok && d.HasChange("description") {
+		datacenterBuilder.Description(description.(string))
+	}
+
+	if local, ok := d.GetOkExists("local"); ok {
+		if d.HasChange("local") {
+			datacenterBuilder.Local(local.(bool))
+		}
+	} else {
+		return fmt.Errorf("DataCenter's local does not exist!")
+	}
+
+	datacenter, err := datacenterBuilder.Build()
+	if err != nil {
+		return err
+	}
+
+	_, err = datacenterService.Update().DataCenter(datacenter).Send()
+
+	if err != nil {
+		return err
+	}
+
+	return resourceOvirtDataCenterRead(d, meta)
+}
+
+func resourceOvirtDataCenterRead(d *schema.ResourceData, meta interface{}) error {
+
+	conn := meta.(*ovirtsdk4.Connection)
+	getDataCenterResp, err := conn.SystemService().DataCentersService().
+		DataCenterService(d.Id()).Get().Send()
+	if err != nil {
+		return err
+	}
+
+	datacenter, ok := getDataCenterResp.DataCenter()
+	if !ok {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", datacenter.MustName())
+	d.Set("local", datacenter.MustLocal())
+
+	if description, ok := datacenter.Description(); ok {
+		d.Set("description", description)
+	}
+
+	return nil
+}
+
+func resourceOvirtDataCenterDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+
+	_, err := conn.SystemService().DataCentersService().
+		DataCenterService(d.Id()).Remove().Send()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/ovirt/resource_ovirt_network.go
+++ b/ovirt/resource_ovirt_network.go
@@ -1,0 +1,207 @@
+// Copyright (C) 2017 Battelle Memorial Institute
+// All rights reserved.
+//
+// This software may be modified and distributed under the terms
+// of the BSD-2 license.  See the LICENSE file for details.
+
+package ovirt
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+)
+
+func resourceOvirtNetwork() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceOvirtNetworkCreate,
+		Read:   resourceOvirtNetworkRead,
+		Update: resourceOvirtNetworkUpdate,
+		Delete: resourceOvirtNetworkDelete,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+			},
+			"datacenter_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+			},
+			"vlan_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: false,
+			},
+			"mtu": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: false,
+			},
+		},
+	}
+}
+
+func resourceOvirtNetworkCreate(d *schema.ResourceData, meta interface{}) error {
+
+	conn := meta.(*ovirtsdk4.Connection)
+	name := d.Get("name").(string)
+	datacenter_id := d.Get("datacenter_id").(string)
+
+	datacenter, err := ovirtsdk4.NewDataCenterBuilder().Id(datacenter_id).Build()
+	if err != nil {
+		return err
+	}
+	//Name and datacenter_id are required when create a datacenter
+	networkbuilder := ovirtsdk4.NewNetworkBuilder().Name(name).
+		DataCenter(datacenter)
+
+	if description, ok := d.GetOkExists("description"); ok {
+		networkbuilder = networkbuilder.Description(description.(string))
+	}
+
+	if vlan_id, ok := d.GetOkExists("vlan_id"); ok {
+		vlan_id_int := vlan_id.(int)
+		vlan, err := ovirtsdk4.NewVlanBuilder().Id(int64(vlan_id_int)).Build()
+		if err != nil {
+			return err
+		}
+		networkbuilder = networkbuilder.Vlan(vlan)
+	}
+
+	if mtu, ok := d.GetOkExists("mtu"); ok {
+		mtu_64_int := mtu.(int)
+		networkbuilder = networkbuilder.Mtu(int64(mtu_64_int))
+	}
+
+	network, err := networkbuilder.Build()
+	if err != nil {
+		return err
+	}
+
+	addResp, err := conn.SystemService().NetworksService().Add().Network(network).Send()
+	if err != nil {
+		return err
+	}
+
+	d.SetId(addResp.MustNetwork().MustId())
+	return resourceOvirtNetworkRead(d, meta)
+
+}
+
+func resourceOvirtNetworkUpdate(d *schema.ResourceData, meta interface{}) error {
+
+	conn := meta.(*ovirtsdk4.Connection)
+	networkService := conn.SystemService().NetworksService().NetworkService(d.Id())
+	networkBuilder := ovirtsdk4.NewNetworkBuilder()
+
+	if name, ok := d.GetOkExists("name"); ok {
+		if d.HasChange("name") {
+			networkBuilder.Name(name.(string))
+		}
+	} else {
+		return fmt.Errorf("Network's name does not exist!")
+	}
+
+	if datacenter_id, ok := d.GetOkExists("datacenter_id"); ok {
+		if d.HasChange("datacenter_id") {
+			datacenter, err := ovirtsdk4.NewDataCenterBuilder().Id(datacenter_id.(string)).Build()
+			if err != nil {
+				return err
+			}
+			networkBuilder.DataCenter(datacenter)
+		}
+	} else {
+		return fmt.Errorf(" Network's 'datacenter_id' does not exist!")
+	}
+
+	if description, ok := d.GetOkExists("description"); ok && d.HasChange("description") {
+		networkBuilder.Description(description.(string))
+	}
+
+	if vlan_id, ok := d.GetOkExists("vlan_id"); ok && d.HasChange("vlan_id") {
+		vlan_id_int := vlan_id.(int)
+		vlan, err := ovirtsdk4.NewVlanBuilder().Id(int64(vlan_id_int)).Build()
+		if err != nil {
+			return err
+		}
+		networkBuilder.Vlan(vlan)
+	}
+
+	if mtu, ok := d.GetOkExists("mtu"); ok && d.HasChange("mtu") {
+		mtu_64_int := mtu.(int)
+		networkBuilder.Mtu(int64(mtu_64_int))
+	}
+
+	network, err := networkBuilder.Build()
+	if err != nil {
+		return err
+	}
+
+	_, err = networkService.Update().Network(network).Send()
+
+	if err != nil {
+		return err
+	}
+
+	return resourceOvirtNetworkRead(d, meta)
+}
+
+func resourceOvirtNetworkRead(d *schema.ResourceData, meta interface{}) error {
+
+	conn := meta.(*ovirtsdk4.Connection)
+	getNetworkResp, err := conn.SystemService().NetworksService().
+		NetworkService(d.Id()).Get().Send()
+	if err != nil {
+		return err
+	}
+
+	network, ok := getNetworkResp.Network()
+	if !ok {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", network.MustName())
+
+	if datacenter, ok := network.DataCenter(); ok {
+		if datacenter_id, ok := datacenter.Id(); ok {
+			d.Set("datacenter_id", datacenter_id)
+		} else {
+			return fmt.Errorf("Network's datacenter_id does not exist!")
+		}
+	}
+
+	if vlan, ok := network.Vlan(); ok {
+		d.Set("vlan_id", vlan.MustId())
+	}
+
+	if description, ok := network.Description(); ok {
+		d.Set("description", description)
+	}
+
+	mtu, ok := network.Mtu()
+	if ok {
+		d.Set("mtu", mtu)
+	}
+
+	return nil
+}
+
+func resourceOvirtNetworkDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+
+	_, err := conn.SystemService().NetworksService().
+		NetworkService(d.Id()).Remove().Send()
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Use the golang sdk of ovirt-engine v4.x to refactor the provider and existing resources/datacenter,resources/network.I tested OK with terraform apply and terraform destroy in my local oVirt-v4.2 dev environment.