### PR TITLE
Add initial acc test for the provider and the datasource of data.ovirt_datacenters

### DIFF
--- a/ovirt/data_source_ovirt_datacenters.go
+++ b/ovirt/data_source_ovirt_datacenters.go
@@ -68,10 +68,10 @@ func dataSourceOvirtDataCentersRead(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("your query datacenter returned no results, please change your search criteria and try again")
 	}
 
-	return dataCentersDecriptionAttributes(d, dcs.Slice(), meta)
+	return dataCentersDescriptionAttributes(d, dcs.Slice(), meta)
 }
 
-func dataCentersDecriptionAttributes(d *schema.ResourceData, dcs []*ovirtsdk4.DataCenter, meta interface{}) error {
+func dataCentersDescriptionAttributes(d *schema.ResourceData, dcs []*ovirtsdk4.DataCenter, meta interface{}) error {
 	var s []map[string]interface{}
 	for _, v := range dcs {
 		mapping := map[string]interface{}{

--- a/ovirt/data_source_ovirt_datacenters_test.go
+++ b/ovirt/data_source_ovirt_datacenters_test.go
@@ -1,0 +1,30 @@
+package ovirt
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccOvirtDataCentersDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckOvirtDataCentersDataSourceBasicConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtDataSourceID("data.ovirt_datacenters.name_filtered_datacenter"),
+					resource.TestCheckResourceAttr("data.ovirt_datacenters.name_filtered_datacenter", "name", "Default"),
+					resource.TestCheckResourceAttr("data.ovirt_datacenters.name_filtered_datacenter", "datacenters.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+var testAccCheckOvirtDataCentersDataSourceBasicConfig = `
+data "ovirt_datacenters" "name_filtered_datacenter" {
+	name = "Default"
+  }
+`

--- a/ovirt/provider.go
+++ b/ovirt/provider.go
@@ -7,6 +7,8 @@
 package ovirt
 
 import (
+	"os"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
@@ -19,17 +21,20 @@ func Provider() terraform.ResourceProvider {
 			"username": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OVIRT_USERNAME", os.Getenv("OVIRT_USERNAME")),
 				Description: "Login username",
 			},
 			"password": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OVIRT_PASSWORD", os.Getenv("OVIRT_PASSWORD")),
 				Description: "Login password",
 				Sensitive:   true,
 			},
 			"url": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OVIRT_URL", os.Getenv("OVIRT_URL")),
 				Description: "Ovirt server url",
 			},
 		},

--- a/ovirt/provider_test.go
+++ b/ovirt/provider_test.go
@@ -1,0 +1,56 @@
+package ovirt
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"ovirt": testAccProvider,
+	}
+}
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestProvider_impl(t *testing.T) {
+	var _ terraform.ResourceProvider = Provider()
+}
+
+func testAccPreCheck(t *testing.T) {
+	if v := os.Getenv("OVIRT_USERNAME"); v == "" {
+		t.Fatal("OVIRT_USERNAME must be set for acceptance tests")
+	}
+	if v := os.Getenv("OVIRT_PASSWORD"); v == "" {
+		t.Fatal("OVIRT_PASSWORD must be set for acceptance tests")
+	}
+	if v := os.Getenv("OVIRT_URL"); v == "" {
+		t.Fatal("OVIRT_URL must be set for acceptance tests")
+	}
+}
+
+func testAccCheckOvirtDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find data source: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("data source ID not set")
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
Since missing acceptance and unit tests, this pr adds basic support for acc testing of the `provider` and `data.ovirt_datacenters`. You could use `OVIRT_USERNAME=your-username OVIRT_PASSWORD=your-password OVIRT_URL=your-url TF_ACC=1 go test ./ovirt -v` to start acceptance testing. More tests would be added soon.

btw: also fixes a typo and adds `DefaultFunc` attribute definitions for `ResourceProvider` schemas.