### PR TITLE
data/ovirt_datacenters: Add support for more filter criteria

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,13 @@ data "ovirt_networks" "my_network_2" {
 }
 
 data "ovirt_datacenters" "defaultDC" {
-  name = "DefaultMy"
+  name_regex = "^De\\w*"
+
+  search = {
+    criteria       = "status = up and Storage.name = data"
+    max            = 10
+    case_sensitive = false
+  }
 }
 
 output "default_dc_id" {

--- a/ovirt/data_source_ovirt_common_schema.go
+++ b/ovirt/data_source_ovirt_common_schema.go
@@ -1,0 +1,28 @@
+package ovirt
+
+import "github.com/hashicorp/terraform/helper/schema"
+
+func dataSourceSearchSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeMap,
+		Optional: true,
+		ForceNew: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"criteria": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"max": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+				"case_sensitive": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+			},
+		},
+	}
+}

--- a/ovirt/data_source_ovirt_datacenters_test.go
+++ b/ovirt/data_source_ovirt_datacenters_test.go
@@ -6,25 +6,52 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccOvirtDataCentersDataSource_basic(t *testing.T) {
+func TestAccOvirtDataCentersDataSource_nameRegexFilter(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckOvirtDataCentersDataSourceBasicConfig,
+				Config: testAccCheckOvirtDataCentersDataSourceNameRegexConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOvirtDataSourceID("data.ovirt_datacenters.name_filtered_datacenter"),
-					resource.TestCheckResourceAttr("data.ovirt_datacenters.name_filtered_datacenter", "name", "Default"),
-					resource.TestCheckResourceAttr("data.ovirt_datacenters.name_filtered_datacenter", "datacenters.#", "1"),
+					testAccCheckOvirtDataSourceID("data.ovirt_datacenters.name_regex_filtered_datacenter"),
+					resource.TestCheckResourceAttr("data.ovirt_datacenters.name_regex_filtered_datacenter", "datacenters.#", "1"),
+					resource.TestCheckResourceAttr("data.ovirt_datacenters.name_regex_filtered_datacenter", "datacenters.0.name", "Default"),
 				),
 			},
 		},
 	})
 }
 
-var testAccCheckOvirtDataCentersDataSourceBasicConfig = `
-data "ovirt_datacenters" "name_filtered_datacenter" {
-	name = "Default"
+func TestAccOvirtDataCentersDataSource_searchFilter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckOvirtDataCentersDataSourceSearchConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtDataSourceID("data.ovirt_datacenters.search_filtered_datacenter"),
+					resource.TestCheckResourceAttr("data.ovirt_datacenters.search_filtered_datacenter", "datacenters.#", "1"),
+					resource.TestCheckResourceAttr("data.ovirt_datacenters.search_filtered_datacenter", "datacenters.0.name", "Default"),
+				),
+			},
+		},
+	})
+}
+
+var testAccCheckOvirtDataCentersDataSourceNameRegexConfig = `
+data "ovirt_datacenters" "name_regex_filtered_datacenter" {
+	name_regex = "^Defa*"
+  }
+`
+
+var testAccCheckOvirtDataCentersDataSourceSearchConfig = `
+data "ovirt_datacenters" "search_filtered_datacenter" {
+	search = {
+	  criteria       = "name = Default and status = up and Storage.name = data"
+	  max            = 2
+	  case_sensitive = false
+	}
   }
 `


### PR DESCRIPTION
Changes proposed in this pull request:

* add `{search = {criteria, max, case_sensitive}}` map attribute
* add `name_regex` attribute
* remove `name` attribute

This could add fully support for the `search criteria` described in [oVirt engine API Model](http://ovirt.github.io/ovirt-engine-api-model/4.3/#_searching)

BTW:
The original `name` filter could be replaced by:
```
  search = {
    criteria = "name = your-dc-name"
  }
```
or 
```
  name_regex = "your-dc-name"
```

Output from acceptance testing:
```
TF_ACC=1 go test ./ovirt -v -run TestAccOvirtDataCentersDataSource_searchFilter
=== RUN   TestAccOvirtDataCentersDataSource_searchFilter
--- PASS: TestAccOvirtDataCentersDataSource_searchFilter (0.91s)
PASS
ok  	github.com/EMSL-MSC/terraform-provider-ovirt/ovirt	(cached)
```