### PR TITLE
data/ovirt_networks: Add support for more filter criteria

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "ovirt_vm" "my_vm_1" {
   #  }
 
   network_interface {
-    network     = "${data.ovirt_networks.my_network_2.name}"
+    network     = "${data.ovirt_networks.my_network_2.networks.0.name}"
     label       = "eth0"
     boot_proto  = "static"
     ip_address  = "130.20.232.184"
@@ -70,7 +70,13 @@ resource "ovirt_network" "my_network_1" {
 }
 
 data "ovirt_networks" "my_network_2" {
-  name = "my_network_2"
+  name_regex = "^my_network_*"
+
+  search = {
+    criteria       = "datacenter = Default and name = my_network_2"
+    max            = 1
+    case_sensitive = false
+  }
 }
 
 data "ovirt_datacenters" "defaultDC" {

--- a/ovirt/data_source_ovirt_networks.go
+++ b/ovirt/data_source_ovirt_networks.go
@@ -9,9 +9,12 @@ package ovirt
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
@@ -19,10 +22,12 @@ func dataSourceOvirtNetworks() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceOvirtNetworksRead,
 		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+			"search": dataSourceSearchSchema(),
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.ValidateRegexp,
 			},
 			"networks": {
 				Type:     schema.TypeList,
@@ -32,6 +37,10 @@ func dataSourceOvirtNetworks() *schema.Resource {
 						"id": {
 							Type:     schema.TypeString,
 							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
 						},
 						"datacenter_id": {
 							Type:     schema.TypeString,
@@ -55,22 +64,68 @@ func dataSourceOvirtNetworks() *schema.Resource {
 		},
 	}
 }
+
 func dataSourceOvirtNetworksRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*ovirtsdk4.Connection)
-	listResp, err := conn.SystemService().NetworksService().
-		List().
-		Search(fmt.Sprintf("name=%s", d.Get("name"))).
-		Send()
+	networksReq := conn.SystemService().NetworksService().List()
+
+	search, searchOK := d.GetOk("search")
+	nameRegex, nameRegexOK := d.GetOk("name_regex")
+
+	if searchOK {
+		searchMap := search.(map[string]interface{})
+		searchCriteria, searchCriteriaOK := searchMap["criteria"]
+		searchMax, searchMaxOK := searchMap["max"]
+		searchCaseSensitive, searchCaseSensitiveOK := searchMap["case_sensitive"]
+		if !searchCriteriaOK && !searchMaxOK && !searchCaseSensitiveOK {
+			return fmt.Errorf("One of criteria or max or case_sensitive in search must be assigned")
+		}
+
+		if searchCriteriaOK {
+			networksReq.Search(searchCriteria.(string))
+		}
+		if searchMaxOK {
+			maxInt, err := strconv.ParseInt(searchMax.(string), 10, 64)
+			if err != nil || maxInt < 1 {
+				return fmt.Errorf("search.max must be a positive int")
+			}
+			networksReq.Max(maxInt)
+		}
+		if searchCaseSensitiveOK {
+			csBool, err := strconv.ParseBool(searchCaseSensitive.(string))
+			if err != nil {
+				return fmt.Errorf("search.case_sensitive must be true or false")
+			}
+			networksReq.CaseSensitive(csBool)
+		}
+	}
+
+	networksResp, err := networksReq.Send()
 	if err != nil {
 		return err
 	}
-
-	networks, ok := listResp.Networks()
+	networks, ok := networksResp.Networks()
 	if !ok && len(networks.Slice()) == 0 {
-		d.SetId("")
-		return fmt.Errorf("Network '%s' not found", d.Get("name"))
+		return fmt.Errorf("your query returned no results, please change your search criteria and try again")
 	}
-	return networksDecriptionAttributes(d, networks.Slice(), meta)
+
+	var filteredNetworks []*ovirtsdk4.Network
+	if nameRegexOK {
+		r := regexp.MustCompile(nameRegex.(string))
+		for _, network := range networks.Slice() {
+			if r.MatchString(network.MustName()) {
+				filteredNetworks = append(filteredNetworks, network)
+			}
+		}
+	} else {
+		filteredNetworks = networks.Slice()[:]
+	}
+
+	if len(filteredNetworks) == 0 {
+		return fmt.Errorf("your query returned no results, please change your search criteria and try again")
+	}
+
+	return networksDecriptionAttributes(d, filteredNetworks, meta)
 }
 
 func networksDecriptionAttributes(d *schema.ResourceData, network []*ovirtsdk4.Network, meta interface{}) error {
@@ -83,6 +138,7 @@ func networksDecriptionAttributes(d *schema.ResourceData, network []*ovirtsdk4.N
 		}
 		mapping := map[string]interface{}{
 			"id":            v.MustId(),
+			"name":          v.MustName(),
 			"datacenter_id": v.MustDataCenter().MustId(),
 			"description":   desc,
 			"vlan_id":       v.MustVlan().MustId(),

--- a/ovirt/data_source_ovirt_networks_test.go
+++ b/ovirt/data_source_ovirt_networks_test.go
@@ -1,0 +1,59 @@
+package ovirt
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccOvirtNetworksDataSource_nameRegexFilter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckOvirtNetworksDataSourceNameRegexConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtDataSourceID("data.ovirt_networks.name_regex_filtered_network"),
+					resource.TestCheckResourceAttr("data.ovirt_networks.name_regex_filtered_network", "networks.#", "1"),
+					resource.TestMatchResourceAttr("data.ovirt_networks.name_regex_filtered_network", "networks.0.name", regexp.MustCompile("^ovirtmgmt-*")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOvirtNetworksDataSource_searchFilter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckOvirtNetworksDataSourceSearchConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtDataSourceID("data.ovirt_networks.search_filtered_network"),
+					resource.TestCheckResourceAttr("data.ovirt_networks.search_filtered_network", "networks.#", "1"),
+					resource.TestCheckResourceAttr("data.ovirt_networks.search_filtered_network", "networks.0.name", "ovirtmgmt-test"),
+				),
+			},
+		},
+	})
+
+}
+
+var testAccCheckOvirtNetworksDataSourceNameRegexConfig = `
+data "ovirt_networks" "name_regex_filtered_network" {
+	name_regex = "^ovirtmgmt-t*"
+  }
+`
+
+var testAccCheckOvirtNetworksDataSourceSearchConfig = `
+data "ovirt_networks" "search_filtered_network" {
+	search = {
+	  criteria       = "datacenter = Default and name = ovirtmgmt-test"
+	  max            = 1
+	  case_sensitive = false
+	}
+}
+`


### PR DESCRIPTION
Changes proposed in this pull request:

* add {search = {criteria, max, case_sensitive}} map attribute
* add name_regex attribute
* remove name attribute

Output from acceptance testing:

```
make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtNetworksDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtNetworksDataSource -timeout 180m
=== RUN   TestAccOvirtNetworksDataSource_nameRegexFilter
--- PASS: TestAccOvirtNetworksDataSource_nameRegexFilter (0.91s)
=== RUN   TestAccOvirtNetworksDataSource_searchFilter
--- PASS: TestAccOvirtNetworksDataSource_searchFilter (0.83s)
PASS
ok  	github.com/EMSL-MSC/terraform-provider-ovirt/ovirt	1.765s
```