### PR TITLE
Check whether vlan exists when quering ovirt_networks Data Source

### DIFF
--- a/ovirt/data_source_ovirt_networks.go
+++ b/ovirt/data_source_ovirt_networks.go
@@ -141,8 +141,10 @@ func networksDecriptionAttributes(d *schema.ResourceData, network []*ovirtsdk4.N
 			"name":          v.MustName(),
 			"datacenter_id": v.MustDataCenter().MustId(),
 			"description":   desc,
-			"vlan_id":       v.MustVlan().MustId(),
 			"mtu":           v.MustMtu(),
+		}
+		if vlan, ok := v.Vlan(); ok {
+			mapping["vlan_id"] = vlan.MustId()
 		}
 		s = append(s, mapping)
 	}


### PR DESCRIPTION
Fixes #20 . 

Changes proposed in this pull request:

* Use `Vlan()` instead of `MustVlan()` when getting the `vlan` attribute.