### PR TITLE
Resource/ovirt_datacenter: Improve implementation and acc testing

### DIFF
--- a/ovirt/resource_ovirt_datacenter_test.go
+++ b/ovirt/resource_ovirt_datacenter_test.go
@@ -25,6 +25,14 @@ func TestAccOvirtDataCenter_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("ovirt_datacenter.datacenter", "local", "false"),
 				),
 			},
+			{
+				Config: testAccDataCenterBasicUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtDataCenterExists("ovirt_datacenter.datacenter", &dc),
+					resource.TestCheckResourceAttr("ovirt_datacenter.datacenter", "name", "testAccOvirtDataCenterBasicUpdate"),
+					resource.TestCheckResourceAttr("ovirt_datacenter.datacenter", "local", "true"),
+				),
+			},
 		},
 	})
 }
@@ -83,5 +91,13 @@ resource "ovirt_datacenter" "datacenter" {
 	name        = "testAccOvirtDataCenterBasic"
 	description = "my new dc"
 	local       = false
+}
+`
+
+const testAccDataCenterBasicUpdate = `
+resource "ovirt_datacenter" "datacenter" {
+	name        = "testAccOvirtDataCenterBasicUpdate"
+	description = "my updated new dc"
+	local       = true
 }
 `


### PR DESCRIPTION
Changes proposed in this pull request:

* Remove `GetOK()` for required fields in update function
* If getting a datacenter returns back a `NotFoundError`, do `d.SetId("")` followed by `return nil` which is not an error.

Output from acceptance testing:

```
$ make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtDataCenter_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtDataCenter_ -timeout 180m
=== RUN   TestAccOvirtDataCenter_basic
--- PASS: TestAccOvirtDataCenter_basic (2.50s)
PASS
ok  	github.com/EMSL-MSC/terraform-provider-ovirt/ovirt	2.529s
```
