### PR TITLE
resource/ovirt_vm: Improve the implementations and fix bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ provider "ovirt" {
   * ovirt_disk_attachment
   * ovirt_datacenter
   * ovirt_network
+  * ovirt_vnic_profile
 * Data Sources
   * ovirt_disks
   * ovirt_datacenters

--- a/ovirt/resource_ovirt_vm_test.go
+++ b/ovirt/resource_ovirt_vm_test.go
@@ -1,0 +1,172 @@
+package ovirt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+)
+
+func TestAccOvirtVM_basic(t *testing.T) {
+	var vm ovirtsdk4.Vm
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		Providers:     testAccProviders,
+		IDRefreshName: "ovirt_vm.vm",
+		CheckDestroy:  testAccCheckVMDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVMBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtVMExists("ovirt_vm.vm", &vm),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "name", "testAccOvirtVMBasic"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.#", "1"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.nic_configuration.#", "2"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "vnic.#", "2"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "attached_disk.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVMDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*ovirtsdk4.Connection)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ovirt_vm" {
+			continue
+		}
+		getResp, err := conn.SystemService().VmsService().
+			VmService(rs.Primary.ID).
+			Get().
+			Send()
+		if err != nil {
+			if _, ok := err.(*ovirtsdk4.NotFoundError); ok {
+				continue
+			}
+			return err
+		}
+		if _, ok := getResp.Vm(); ok {
+			return fmt.Errorf("VM %s still exist", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckOvirtVMExists(n string, v *ovirtsdk4.Vm) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No VM ID is set")
+		}
+		conn := testAccProvider.Meta().(*ovirtsdk4.Connection)
+		getResp, err := conn.SystemService().VmsService().
+			VmService(rs.Primary.ID).
+			Get().
+			Send()
+		if err != nil {
+			return err
+		}
+		vm, ok := getResp.Vm()
+		if ok {
+			*v = *vm
+			return nil
+		}
+		return fmt.Errorf("VM %s not exist", rs.Primary.ID)
+	}
+}
+
+const testAccVMBasic = `
+resource "ovirt_vm" "vm" {
+	name        = "testAccOvirtVMBasic"
+	cluster_id  = "${data.ovirt_clusters.default.clusters.0.id}"
+
+	initialization = {
+		authorized_ssh_key = "${file(pathexpand("~/.ssh/id_rsa.pub"))}"
+		nic_configuration {
+			label       = "eth0"
+			boot_proto  = "static"
+			address  	= "10.1.60.60"
+			gateway     = "10.1.60.1"
+			netmask 	= "255.255.255.0"
+		}
+		nic_configuration {
+			label       = "eth1"
+			boot_proto  = "static"
+			address  	= "10.1.60.61"
+			gateway     = "10.1.60.1"
+			netmask 	= "255.255.255.0"
+		}
+	}
+
+	vnic {
+		name  			= "nic1"
+		vnic_profile_id = "${ovirt_vnic_profile.vm_vnic_profile.id}"
+	}
+
+	vnic {
+		name  			= "nic2"
+		vnic_profile_id = "${ovirt_vnic_profile.vm_vnic_profile.id}"
+	}
+
+	attached_disk {
+		disk_id = "${ovirt_disk.vm_disk.id}"
+		bootable = true
+		interface = "virtio"
+	}
+}
+
+resource "ovirt_disk" "vm_disk" {
+	name              = "vm_disk"
+	alias             = "vm_disk"
+	size              = 23687091200
+	format            = "cow"
+	storage_domain_id = "${data.ovirt_storagedomains.data.storagedomains.0.id}"
+	sparse            = true
+}
+
+data "ovirt_storagedomains" "data" {
+	name_regex = "^data"
+	search = {
+	  criteria       = "name = data and datacenter = ${data.ovirt_datacenters.default.datacenters.0.name}"
+	  case_sensitive = false
+	}
+}
+
+data "ovirt_datacenters" "default" {
+	search = {
+		criteria       = "name = Default"
+		max            = 1
+		case_sensitive = false
+	}
+}
+
+data "ovirt_clusters" "default" {
+	search = {
+		criteria       = "name = Default"
+		max            = 1
+		case_sensitive = false
+	}
+}
+
+resource "ovirt_vnic_profile" "vm_vnic_profile" {
+	name        	= "vm_vnic_profile"
+	network_id  	= "${data.ovirt_networks.ovirtmgmt.networks.0.id}"
+	migratable  	= true
+	port_mirroring 	= true
+}
+
+data "ovirt_networks" "ovirtmgmt" {
+	search = {
+	  criteria       = "datacenter = Default and name = ovirtmgmt"
+	  max            = 1
+	  case_sensitive = false
+	}
+}
+
+`


### PR DESCRIPTION
Partially Fixes issue #32. 

Changes proposed in this pull request:

* Add `attached_disk` field in `ovirt_vm` resource
> Current `ovirt_disk_attachment` resource has lots of limitations. For example, the add/update/delete a disk attachment typically requires changing relevant VM lifecycle status, but it's confusing that the lifecycle operation is done by `ovirt_disk_attachment` Resource. The old  `ovirt_disk_attachment` Resource may mark as `deprecated` in the near future.

* Wait until the VM is up at the end of VM creation
> Thanks to the newly added `attached_disk` field. 😄 

* Add `vnic` field with the type of `schema.TypeSet`, to represent the vnic configurations for VM
* Rename `network_interace` field to `nic_configuration`, to represent the network initialization configurations
* Add `initialization` field and get `authorized_ssh_key` and `nic_configuration` moved in
> The above three changes are to completely distinguish the `vnic` settings from the `initialization network configurations` which are both optional attribute that be able to configured respectively. Meanwhile set `initialization` as independent field representing the [VM initialization structure](
http://ovirt.github.io/ovirt-engine-api-model/master/#types/initialization).

* Add `cluster_id` field to replace the `cluster` (which is the cluster name)

* Set all fields to `ForceNew: true` to support Terraform update operations
> This is a temporary way and will be fixed soon.

* Complete the `resourceOvirtVMRead` function

* Add retry mechanism in deleting the disk

* Add an acceptance test of common case  for `ovirt_vm` resource

* Update main.tf

Output from the acceptance test: (Updated after #42 got merged)
```
make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtVM_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtVM_ -timeout 180m
=== RUN   TestAccOvirtVM_basic
--- PASS: TestAccOvirtVM_basic (98.66s)
PASS
ok  	github.com/EMSL-MSC/terraform-provider-ovirt/ovirt	98.690s
```