### PR TITLE
Add New Resource: ovirt_vnic_profile

### DIFF
--- a/ovirt/provider.go
+++ b/ovirt/provider.go
@@ -45,6 +45,7 @@ func Provider() terraform.ResourceProvider {
 			"ovirt_disk_attachment": resourceOvirtDiskAttachment(),
 			"ovirt_datacenter":      resourceOvirtDataCenter(),
 			"ovirt_network":         resourceOvirtNetwork(),
+			"ovirt_vnic_profile":    resourceOvirtVnicProfile(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"ovirt_disks":          dataSourceOvirtDisks(),

--- a/ovirt/resource_ovirt_vnic_profile.go
+++ b/ovirt/resource_ovirt_vnic_profile.go
@@ -1,0 +1,148 @@
+package ovirt
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+)
+
+func resourceOvirtVnicProfile() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceOvirtVnicProfileCreate,
+		Read:   resourceOvirtVnicProfileRead,
+		Update: resourceOvirtVnicProfileUpdate,
+		Delete: resourceOvirtVnicProfileDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"network_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"migratable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"port_mirroring": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func resourceOvirtVnicProfileCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+
+	network := ovirtsdk4.NewNetworkBuilder().Id(d.Get("network_id").(string)).MustBuild()
+	builder := ovirtsdk4.NewVnicProfileBuilder()
+
+	builder.Network(network)
+	builder.Name(d.Get("name").(string))
+	if v, ok := d.GetOk("migratable"); ok {
+		builder.Migratable(v.(bool))
+	}
+	if v, ok := d.GetOk("port_mirroring"); ok {
+		builder.PortMirroring(v.(bool))
+	}
+
+	addResp, err := conn.SystemService().VnicProfilesService().
+		Add().
+		Profile(builder.MustBuild()).
+		Send()
+	if err != nil {
+		return err
+	}
+
+	d.SetId(addResp.MustProfile().MustId())
+
+	return resourceOvirtVnicProfileRead(d, meta)
+}
+
+func resourceOvirtVnicProfileRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+	getResp, err := conn.SystemService().VnicProfilesService().
+		ProfileService(d.Id()).
+		Get().
+		Send()
+	if err != nil {
+		if _, ok := err.(*ovirtsdk4.NotFoundError); ok {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+	profile, ok := getResp.Profile()
+	if !ok {
+		d.SetId("")
+		return nil
+	}
+	d.Set("name", profile.MustName())
+	d.Set("network_id", profile.MustNetwork().MustId())
+	if v, ok := profile.Migratable(); ok {
+		d.Set("migratable", v)
+	}
+	if v, ok := profile.PortMirroring(); ok {
+		d.Set("port_mirroring", v)
+	}
+
+	return nil
+}
+
+func resourceOvirtVnicProfileUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+	profileService := conn.SystemService().VnicProfilesService().ProfileService(d.Id())
+
+	newBuilder := ovirtsdk4.NewVnicProfileBuilder()
+	if d.HasChange("name") {
+		newBuilder.Name(d.Get("name").(string))
+	}
+	if d.HasChange("migratable") {
+		newBuilder.Migratable(d.Get("migratable").(bool))
+	}
+	if d.HasChange("port_mirroring") {
+		newBuilder.PortMirroring(d.Get("port_mirroring").(bool))
+	}
+	_, err := profileService.Update().
+		Profile(newBuilder.MustBuild()).
+		Send()
+	if err != nil {
+		return err
+	}
+
+	return resourceOvirtVnicProfileRead(d, meta)
+}
+
+func resourceOvirtVnicProfileDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+
+	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+		_, e := conn.SystemService().VnicProfilesService().
+			ProfileService(d.Id()).
+			Remove().
+			Send()
+		if e != nil {
+			if _, ok := e.(*ovirtsdk4.NotFoundError); ok {
+				return nil
+			}
+			return resource.RetryableError(fmt.Errorf("failed to delete vnicpfole: %s, wait for next run", e))
+		}
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/ovirt/resource_ovirt_vnic_profile_test.go
+++ b/ovirt/resource_ovirt_vnic_profile_test.go
@@ -1,0 +1,123 @@
+package ovirt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+)
+
+func TestAccOvirtVnicProfile_basic(t *testing.T) {
+	var profile ovirtsdk4.VnicProfile
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckVnicProfileDestroy,
+		IDRefreshName: "ovirt_vnic_profile.profile",
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVnicProfileBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtVnicProfileExists("ovirt_vnic_profile.profile", &profile),
+					resource.TestCheckResourceAttr("ovirt_vnic_profile.profile", "name", "testAccOvirtVnicProfileBasic"),
+					resource.TestCheckResourceAttr("ovirt_vnic_profile.profile", "migratable", "false"),
+					resource.TestCheckResourceAttr("ovirt_vnic_profile.profile", "port_mirroring", "false"),
+				),
+			},
+			{
+				Config: testAccVnicProfileBasicUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtVnicProfileExists("ovirt_vnic_profile.profile", &profile),
+					resource.TestCheckResourceAttr("ovirt_vnic_profile.profile", "name", "testAccOvirtVnicProfileBasicUpdate"),
+					resource.TestCheckResourceAttr("ovirt_vnic_profile.profile", "migratable", "true"),
+					resource.TestCheckResourceAttr("ovirt_vnic_profile.profile", "port_mirroring", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVnicProfileDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*ovirtsdk4.Connection)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ovirt_vnic_profile" {
+			continue
+		}
+		getResp, err := conn.SystemService().VnicProfilesService().
+			ProfileService(rs.Primary.ID).
+			Get().
+			Send()
+		if err != nil {
+			if _, ok := err.(*ovirtsdk4.NotFoundError); ok {
+				continue
+			}
+			return err
+		}
+		if _, ok := getResp.Profile(); ok {
+			return fmt.Errorf("VnicProfile %s still exist", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckOvirtVnicProfileExists(n string, v *ovirtsdk4.VnicProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No VnicProfile ID is set")
+		}
+		conn := testAccProvider.Meta().(*ovirtsdk4.Connection)
+		getResp, err := conn.SystemService().VnicProfilesService().
+			ProfileService(rs.Primary.ID).
+			Get().
+			Send()
+		if err != nil {
+			return err
+		}
+		profile, ok := getResp.Profile()
+		if ok {
+			*v = *profile
+			return nil
+		}
+		return fmt.Errorf("VnicProfile %s not exist", rs.Primary.ID)
+	}
+}
+
+const testAccVnicProfileBasic = `
+data "ovirt_networks" "ovirtmgmt-test" {
+	search {
+		criteria       = "datacenter = Default and name = ovirtmgmt-test"
+		max            = 1
+		case_sensitive = false
+	}
+}
+
+resource "ovirt_vnic_profile" "profile" {
+	name        	= "testAccOvirtVnicProfileBasic"
+	network_id  	= "${data.ovirt_networks.ovirtmgmt-test.networks.0.id}"
+	migratable  	= false
+	port_mirroring 	= false
+}
+`
+
+const testAccVnicProfileBasicUpdate = `
+data "ovirt_networks" "ovirtmgmt-test" {
+	search {
+		criteria       = "datacenter = Default and name = ovirtmgmt-test"
+		max            = 1
+		case_sensitive = false
+	}
+}
+
+resource "ovirt_vnic_profile" "profile" {
+	name        	= "testAccOvirtVnicProfileBasicUpdate"
+	network_id  	= "${data.ovirt_networks.ovirtmgmt-test.networks.0.id}"
+	migratable  	= true
+	port_mirroring 	= true
+}
+`


### PR DESCRIPTION
Changes proposed in this pull request:

* Add new `ovirt_vnic_profile` Resource
* Add support for `name`, `network_id`, `migratable`, `port_mirroring` fields

Output from acceptance test:

```
make testacc TEST=./ovirt  TESTARGS='-run=TestAccOvirtVnicProfile_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtVnicProfile_ -timeout 180m
=== RUN   TestAccOvirtVnicProfile_basic
--- PASS: TestAccOvirtVnicProfile_basic (2.69s)
PASS
ok      github.com/EMSL-MSC/terraform-provider-ovirt/ovirt      2.718s
```