### PR TITLE
resource/ovirt_vm: Add support for more initialization fields

### DIFF
--- a/ovirt/resource_ovirt_vm.go
+++ b/ovirt/resource_ovirt_vm.go
@@ -118,6 +118,36 @@ func resourceOvirtVM() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"host_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"timezone": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"user_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"custom_script": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"dns_servers": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"dns_search": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
 						"nic_configuration": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -406,8 +436,26 @@ func expandOvirtVMInitialization(l []interface{}) (*ovirtsdk4.Initialization, er
 	}
 	s := l[0].(map[string]interface{})
 	initializationBuilder := ovirtsdk4.NewInitializationBuilder()
+	if v, ok := s["host_name"]; ok {
+		initializationBuilder.HostName(v.(string))
+	}
+	if v, ok := s["timezone"]; ok {
+		initializationBuilder.Timezone(v.(string))
+	}
+	if v, ok := s["user_name"]; ok {
+		initializationBuilder.UserName(v.(string))
+	}
+	if v, ok := s["custom_script"]; ok {
+		initializationBuilder.CustomScript(v.(string))
+	}
 	if v, ok := s["authorized_ssh_key"]; ok {
 		initializationBuilder.AuthorizedSshKeys(v.(string))
+	}
+	if v, ok := s["dns_servers"]; ok {
+		initializationBuilder.DnsServers(v.(string))
+	}
+	if v, ok := s["dns_search"]; ok {
+		initializationBuilder.DnsSearch(v.(string))
 	}
 	if v, ok := s["nic_configuration"]; ok {
 		ncs, err := expandOvirtVMNicConfigurations(v.([]interface{}))
@@ -574,6 +622,25 @@ func flattenOvirtVMInitialization(configured *ovirtsdk4.Initialization) []map[st
 	}
 	initializations := make([]map[string]interface{}, 1)
 	initialization := make(map[string]interface{})
+
+	if v, ok := configured.HostName(); ok {
+		initialization["host_name"] = v
+	}
+	if v, ok := configured.Timezone(); ok {
+		initialization["timezone"] = v
+	}
+	if v, ok := configured.UserName(); ok {
+		initialization["user_name"] = v
+	}
+	if v, ok := configured.CustomScript(); ok {
+		initialization["custom_script"] = v
+	}
+	if v, ok := configured.DnsServers(); ok {
+		initialization["dns_servers"] = v
+	}
+	if v, ok := configured.DnsSearch(); ok {
+		initialization["dns_search"] = v
+	}
 	if v, ok := configured.AuthorizedSshKeys(); ok {
 		initialization["authorized_ssh_key"] = v
 	}

--- a/ovirt/resource_ovirt_vm_test.go
+++ b/ovirt/resource_ovirt_vm_test.go
@@ -24,6 +24,12 @@ func TestAccOvirtVM_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("ovirt_vm.vm", "name", "testAccOvirtVMBasic"),
 					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.#", "1"),
 					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.nic_configuration.#", "2"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.host_name", "vm-basic-1"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.timezone", "Asia/Shanghai"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.user_name", "root"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.custom_script", "echo hello"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.dns_search", "university.edu"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.dns_servers", "8.8.8.8,8.8.4.4"),
 					resource.TestCheckResourceAttr("ovirt_vm.vm", "vnic.#", "2"),
 					resource.TestCheckResourceAttr("ovirt_vm.vm", "attached_disk.#", "1"),
 				),
@@ -87,6 +93,12 @@ resource "ovirt_vm" "vm" {
 	cluster_id  = "${data.ovirt_clusters.default.clusters.0.id}"
 
 	initialization = {
+		host_name = "vm-basic-1"
+		timezone = "Asia/Shanghai"
+		user_name = "root"
+		custom_script = "echo hello"
+		dns_search = "university.edu"
+		dns_servers = "8.8.8.8,8.8.4.4"
 		authorized_ssh_key = "${file(pathexpand("~/.ssh/id_rsa.pub"))}"
 		nic_configuration {
 			label       = "eth0"


### PR DESCRIPTION
For issue #38 .

Changes proposed in this pull request:

* Add `host_name`, `timezone`, `user_name`, `custom_script`, `dns_servers`, `dns_search` fields in `initialization` schema
* Improve acceptance test for these

Output from acceptance test:

```
make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtVM_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtVM_ -timeout 180m
=== RUN   TestAccOvirtVM_basic
--- PASS: TestAccOvirtVM_basic (86.24s)
PASS
ok  	github.com/EMSL-MSC/terraform-provider-ovirt/ovirt	86.265s
```