### PR TITLE
Add support for updating attacheddisk/vnic/initialization fields

### DIFF
--- a/ovirt/resource_ovirt_vm_test.go
+++ b/ovirt/resource_ovirt_vm_test.go
@@ -21,7 +21,8 @@ func TestAccOvirtVM_basic(t *testing.T) {
 				Config: testAccVMBasic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOvirtVMExists("ovirt_vm.vm", &vm),
-					resource.TestCheckResourceAttr("ovirt_vm.vm", "name", "testAccOvirtVMBasic"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "name", "testAccVMBasic"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "status", "up"),
 					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.#", "1"),
 					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.nic_configuration.#", "2"),
 					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.host_name", "vm-basic-1"),
@@ -29,9 +30,88 @@ func TestAccOvirtVM_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.user_name", "root"),
 					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.custom_script", "echo hello"),
 					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.dns_search", "university.edu"),
-					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.dns_servers", "8.8.8.8,8.8.4.4"),
-					resource.TestCheckResourceAttr("ovirt_vm.vm", "vnic.#", "2"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.dns_servers", "8.8.8.8 8.8.4.4"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.nic_configuration.0.label", "eth0"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.nic_configuration.0.address", "10.1.60.60"),
+				),
+			},
+			{
+				Config: testAccVMBasicUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtVMExists("ovirt_vm.vm", &vm),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "name", "testAccVMBasic"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "status", "up"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.#", "1"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.nic_configuration.#", "1"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.host_name", "vm-basic-updated"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.timezone", "Asia/Shanghai"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.user_name", "root"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.custom_script", "echo hello2"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.dns_search", "university.edu"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.dns_servers", "8.8.8.8"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.authorized_ssh_key", ""),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.nic_configuration.0.label", "eth0"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.nic_configuration.0.address", "10.1.60.66"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOvirtVM_attachedDisk(t *testing.T) {
+	var vm ovirtsdk4.Vm
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		Providers:     testAccProviders,
+		IDRefreshName: "ovirt_vm.vm",
+		CheckDestroy:  testAccCheckVMDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVMAttachedDisk,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtVMExists("ovirt_vm.vm", &vm),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "name", "testAccVMAttachedDisk"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "status", "up"),
 					resource.TestCheckResourceAttr("ovirt_vm.vm", "attached_disk.#", "1"),
+				),
+			},
+			{
+				Config: testAccVMAttachedDiskUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtVMExists("ovirt_vm.vm", &vm),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "name", "testAccVMAttachedDisk"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "status", "up"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "attached_disk.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOvirtVM_vnic(t *testing.T) {
+	var vm ovirtsdk4.Vm
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		Providers:     testAccProviders,
+		IDRefreshName: "ovirt_vm.vm",
+		CheckDestroy:  testAccCheckVMDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVMVnic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtVMExists("ovirt_vm.vm", &vm),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "name", "testAccVMVnic"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "status", "up"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "vnic.#", "2"),
+				),
+			},
+			{
+				Config: testAccVMVnicUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtVMExists("ovirt_vm.vm", &vm),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "name", "testAccVMVnic"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "status", "up"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "vnic.#", "1"),
 				),
 			},
 		},
@@ -89,16 +169,16 @@ func testAccCheckOvirtVMExists(n string, v *ovirtsdk4.Vm) resource.TestCheckFunc
 
 const testAccVMBasic = `
 resource "ovirt_vm" "vm" {
-	name        = "testAccOvirtVMBasic"
+	name        = "testAccVMBasic"
 	cluster_id  = "${data.ovirt_clusters.default.clusters.0.id}"
 
-	initialization = {
+	initialization {
 		host_name = "vm-basic-1"
 		timezone = "Asia/Shanghai"
 		user_name = "root"
 		custom_script = "echo hello"
 		dns_search = "university.edu"
-		dns_servers = "8.8.8.8,8.8.4.4"
+		dns_servers = "8.8.8.8 8.8.4.4"
 		authorized_ssh_key = "${file(pathexpand("~/.ssh/id_rsa.pub"))}"
 		nic_configuration {
 			label       = "eth0"
@@ -115,6 +195,225 @@ resource "ovirt_vm" "vm" {
 			netmask 	= "255.255.255.0"
 		}
 	}
+
+	attached_disk {
+		disk_id = "${ovirt_disk.vm_disk.id}"
+		bootable = true
+		interface = "virtio"
+	}
+}
+
+resource "ovirt_disk" "vm_disk" {
+	name              = "vm_disk"
+	alias             = "vm_disk"
+	size              = 23687091200
+	format            = "cow"
+	storage_domain_id = "${data.ovirt_storagedomains.data.storagedomains.0.id}"
+	sparse            = true
+}
+
+data "ovirt_storagedomains" "data" {
+	name_regex = "^data"
+	search = {
+	  criteria       = "name = data and datacenter = ${data.ovirt_datacenters.default.datacenters.0.name}"
+	  case_sensitive = false
+	}
+}
+
+data "ovirt_datacenters" "default" {
+	search = {
+		criteria       = "name = Default"
+		max            = 1
+		case_sensitive = false
+	}
+}
+
+data "ovirt_clusters" "default" {
+	search = {
+		criteria       = "name = Default"
+		max            = 1
+		case_sensitive = false
+	}
+}
+
+`
+
+const testAccVMBasicUpdate = `
+resource "ovirt_vm" "vm" {
+	name        = "testAccVMBasic"
+	cluster_id  = "${data.ovirt_clusters.default.clusters.0.id}"
+
+	initialization {
+		host_name = "vm-basic-updated"
+		timezone = "Asia/Shanghai"
+		user_name = "root"
+		custom_script = "echo hello2"
+		dns_search = "university.edu"
+		dns_servers = "8.8.8.8"
+		nic_configuration {
+			label       = "eth0"
+			boot_proto  = "static"
+			address  	= "10.1.60.66"
+			gateway     = "10.1.60.1"
+			netmask 	= "255.255.255.0"
+		}
+	}
+
+	attached_disk {
+		disk_id = "${ovirt_disk.vm_disk.id}"
+		bootable = true
+		interface = "virtio"
+	}
+
+}
+
+resource "ovirt_disk" "vm_disk" {
+	name              = "vm_disk"
+	alias             = "vm_disk"
+	size              = 23687091200
+	format            = "cow"
+	storage_domain_id = "${data.ovirt_storagedomains.data.storagedomains.0.id}"
+	sparse            = true
+}
+
+data "ovirt_storagedomains" "data" {
+	name_regex = "^data"
+	search = {
+	  criteria       = "name = data and datacenter = ${data.ovirt_datacenters.default.datacenters.0.name}"
+	  case_sensitive = false
+	}
+}
+
+data "ovirt_datacenters" "default" {
+	search = {
+		criteria       = "name = Default"
+		max            = 1
+		case_sensitive = false
+	}
+}
+
+data "ovirt_clusters" "default" {
+	search = {
+		criteria       = "name = Default"
+		max            = 1
+		case_sensitive = false
+	}
+}
+
+`
+
+const testAccVMAttachedDisk = `
+resource "ovirt_vm" "vm" {
+	name        = "testAccVMAttachedDisk"
+	cluster_id  = "${data.ovirt_clusters.default.clusters.0.id}"
+
+	attached_disk {
+		disk_id = "${ovirt_disk.vm_disk.id}"
+		bootable = true
+		interface = "virtio"
+	}
+}
+
+resource "ovirt_disk" "vm_disk" {
+	name              = "vm_disk"
+	alias             = "vm_disk"
+	size              = 23687091200
+	format            = "cow"
+	storage_domain_id = "${data.ovirt_storagedomains.data.storagedomains.0.id}"
+	sparse            = true
+}
+
+data "ovirt_storagedomains" "data" {
+	name_regex = "^data"
+	search = {
+	  criteria       = "name = data and datacenter = ${data.ovirt_datacenters.default.datacenters.0.name}"
+	  case_sensitive = false
+	}
+}
+
+data "ovirt_datacenters" "default" {
+	search = {
+		criteria       = "name = Default"
+		max            = 1
+		case_sensitive = false
+	}
+}
+
+data "ovirt_clusters" "default" {
+	search = {
+		criteria       = "name = Default"
+		max            = 1
+		case_sensitive = false
+	}
+}
+
+`
+
+const testAccVMAttachedDiskUpdate = `
+resource "ovirt_vm" "vm" {
+	name        = "testAccVMAttachedDisk"
+	cluster_id  = "${data.ovirt_clusters.default.clusters.0.id}"
+
+	attached_disk {
+		disk_id = "${ovirt_disk.vm_disk.id}"
+		bootable = true
+		interface = "virtio"
+	}
+
+	attached_disk {
+		disk_id = "${ovirt_disk.vm_disk_2.id}"
+		bootable = false
+		interface = "virtio"
+	}
+}
+
+resource "ovirt_disk" "vm_disk" {
+	name              = "vm_disk"
+	alias             = "vm_disk"
+	size              = 23687091200
+	format            = "cow"
+	storage_domain_id = "${data.ovirt_storagedomains.data.storagedomains.0.id}"
+	sparse            = true
+}
+
+resource "ovirt_disk" "vm_disk_2" {
+	name              = "vm_disk_2"
+	alias             = "vm_disk_2"
+	size              = 23687091200
+	format            = "cow"
+	storage_domain_id = "${data.ovirt_storagedomains.data.storagedomains.0.id}"
+	sparse            = true
+}
+
+data "ovirt_storagedomains" "data" {
+	name_regex = "^data"
+	search = {
+	  criteria       = "name = data and datacenter = ${data.ovirt_datacenters.default.datacenters.0.name}"
+	  case_sensitive = false
+	}
+}
+
+data "ovirt_datacenters" "default" {
+	search = {
+		criteria       = "name = Default"
+		max            = 1
+		case_sensitive = false
+	}
+}
+
+data "ovirt_clusters" "default" {
+	search = {
+		criteria       = "name = Default"
+		max            = 1
+		case_sensitive = false
+	}
+}
+`
+
+const testAccVMVnic = `
+resource "ovirt_vm" "vm" {
+	name        = "testAccVMVnic"
+	cluster_id  = "${data.ovirt_clusters.default.clusters.0.id}"
 
 	vnic {
 		name  			= "nic1"
@@ -169,8 +468,75 @@ data "ovirt_clusters" "default" {
 resource "ovirt_vnic_profile" "vm_vnic_profile" {
 	name        	= "vm_vnic_profile"
 	network_id  	= "${data.ovirt_networks.ovirtmgmt.networks.0.id}"
-	migratable  	= true
-	port_mirroring 	= true
+	migratable  	= false
+	port_mirroring 	= false
+}
+
+data "ovirt_networks" "ovirtmgmt" {
+	search = {
+	  criteria       = "datacenter = Default and name = ovirtmgmt"
+	  max            = 1
+	  case_sensitive = false
+	}
+}
+
+`
+
+const testAccVMVnicUpdate = `
+resource "ovirt_vm" "vm" {
+	name        = "testAccVMVnic"
+	cluster_id  = "${data.ovirt_clusters.default.clusters.0.id}"
+
+	vnic {
+		name  			= "nic11"
+		vnic_profile_id = "${ovirt_vnic_profile.vm_vnic_profile.id}"
+	}
+
+	attached_disk {
+		disk_id = "${ovirt_disk.vm_disk.id}"
+		bootable = true
+		interface = "virtio"
+	}
+}
+
+resource "ovirt_disk" "vm_disk" {
+	name              = "vm_disk"
+	alias             = "vm_disk"
+	size              = 23687091200
+	format            = "cow"
+	storage_domain_id = "${data.ovirt_storagedomains.data.storagedomains.0.id}"
+	sparse            = true
+}
+
+data "ovirt_storagedomains" "data" {
+	name_regex = "^data"
+	search = {
+	  criteria       = "name = data and datacenter = ${data.ovirt_datacenters.default.datacenters.0.name}"
+	  case_sensitive = false
+	}
+}
+
+data "ovirt_datacenters" "default" {
+	search = {
+		criteria       = "name = Default"
+		max            = 1
+		case_sensitive = false
+	}
+}
+
+data "ovirt_clusters" "default" {
+	search = {
+		criteria       = "name = Default"
+		max            = 1
+		case_sensitive = false
+	}
+}
+
+resource "ovirt_vnic_profile" "vm_vnic_profile" {
+	name        	= "vm_vnic_profile"
+	network_id  	= "${data.ovirt_networks.ovirtmgmt.networks.0.id}"
+	migratable  	= false
+	port_mirroring 	= false
 }
 
 data "ovirt_networks" "ovirtmgmt" {


### PR DESCRIPTION
Partially fixes issue #32 .

Changes proposed in this pull request:

* Add support for updating a VM, currently support `attached_disk`, `vnic` and `inititialization` fields only.
* Add acceptance test for `resource/vm`.

Output from acceptance testing:

```
make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtVM_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtVM_ -timeout 180m
=== RUN   TestAccOvirtVM_basic
--- PASS: TestAccOvirtVM_basic (94.49s)
=== RUN   TestAccOvirtVM_attachedDisk
--- PASS: TestAccOvirtVM_attachedDisk (112.73s)
=== RUN   TestAccOvirtVM_vnic
--- PASS: TestAccOvirtVM_vnic (156.78s)
PASS
ok  	github.com/EMSL-MSC/terraform-provider-ovirt/ovirt	364.039s
```