### PR TITLE
Data ovirt vnic profiles

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,12 @@ resource "ovirt_vm" "my_vm_1" {
   }
 
   vnic {
-    name            = "nic1"
+    name            = "nic2"
+    vnic_profile_id = "${ovirt_vnic_profile.vm_vnic_profile.id}"
+  }
+
+    vnic {
+    name            = "nic3"
     vnic_profile_id = "${ovirt_vnic_profile.vm_vnic_profile.id}"
   }
 
@@ -95,6 +100,11 @@ data "ovirt_networks" "my_network_2" {
     max            = 1
     case_sensitive = false
   }
+}
+
+data "ovirt_vnic_profiles" "vm_vnic_profile01" {
+  name_regex = "^my_network_2*"
+  network_id = "${data.ovirt_networks.my_network_2.networks.0.id}"
 }
 
 data "ovirt_datacenters" "defaultDC" {

--- a/ovirt/data_source_ovirt_vnic_profiles.go
+++ b/ovirt/data_source_ovirt_vnic_profiles.go
@@ -1,0 +1,98 @@
+// Copyright (C) 2017 Battelle Memorial Institute
+// Copyright (C) 2018 Boris Manojlovic
+// All rights reserved.
+//
+// This software may be modified and distributed under the terms
+// of the BSD-2 license.  See the LICENSE file for details.
+
+package ovirt
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform/helper/resource"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+)
+
+func dataSourceOvirtVNicProfiles() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceOvirtVNicProfilesRead,
+		Schema: map[string]*schema.Schema{
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.ValidateRegexp,
+			},
+			"network_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+			},
+			"vnic_profiles": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"network_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"migratable": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"port_mirroring": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceOvirtVNicProfilesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+	profilesService := conn.SystemService().VnicProfilesService()
+	pfsResp, _ := profilesService.List().Send()
+	pfSlice, _ := pfsResp.Profiles()
+	var s []map[string]interface{}
+	rexName := regexp.MustCompile(d.Get("name_regex").(string))
+	networkID := d.Get("network_id")
+
+	for _, pf := range pfSlice.Slice() {
+		if rexName.FindString(pf.MustName()) != "" &&
+			networkID == pf.MustNetwork().MustId() {
+			mapping := map[string]interface{}{
+				"id":             pf.MustId(),
+				"name":           pf.MustName(),
+				"network_id":     pf.MustNetwork().MustId(),
+				"port_mirroring": pf.MustPortMirroring(),
+			}
+			if migratable, ok := pf.Migratable(); ok {
+				mapping["migratable"] = migratable
+			}
+			s = append(s, mapping)
+		}
+	}
+	if len(s) == 0 {
+		return fmt.Errorf("your query returned no results, please change your search criteria and try again")
+	}
+	d.SetId(resource.UniqueId())
+	err := d.Set("vnic_profiles", s)
+	return err
+}

--- a/ovirt/data_source_ovirt_vnic_profiles_test.go
+++ b/ovirt/data_source_ovirt_vnic_profiles_test.go
@@ -1,0 +1,33 @@
+package ovirt
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccOvirtVNicProfilesDataSource_nameRegexFilter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckOvirtVNicProfilesDataSourceNameRegexConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtDataSourceID("data.ovirt_vnic_profiles.name_regex_filtered_cluster"),
+					resource.TestCheckResourceAttr("data.ovirt_vnic_profiles.name_regex_filtered_cluster", "vnic_profiles.#", "2"),
+					resource.TestMatchResourceAttr("data.ovirt_vnic_profiles.name_regex_filtered_cluster", "vnic_profiles.0.name", regexp.MustCompile("^mirror*")),
+					resource.TestMatchResourceAttr("data.ovirt_vnic_profiles.name_regex_filtered_cluster", "vnic_profiles.1.name", regexp.MustCompile("^no_mirror*")),
+				),
+			},
+		},
+	})
+}
+
+var testAccCheckOvirtVNicProfilesDataSourceNameRegexConfig = `
+data "ovirt_vnic_profiles" "name_regex_filtered_cluster" {
+	name_regex = ".*mirror$"
+	network_id = "649f2d61-7f23-477b-93bd-d55f974d8bc8"
+  }
+`

--- a/ovirt/provider.go
+++ b/ovirt/provider.go
@@ -53,6 +53,7 @@ func Provider() terraform.ResourceProvider {
 			"ovirt_networks":       dataSourceOvirtNetworks(),
 			"ovirt_clusters":       dataSourceOvirtClusters(),
 			"ovirt_storagedomains": dataSourceOvirtStorageDomains(),
+			"ovirt_vnic_profiles":  dataSourceOvirtVNicProfiles(),
 		},
 	}
 }


### PR DESCRIPTION
Initial implementation of vnic_profiles data

Changes proposed in this pull request:

* Initial implementation of vnic_profiles data

```
make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtVNicProfilesDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtVNicProfilesDataSource_ -timeout 180m
=== RUN   TestAccOvirtVNicProfilesDataSource_nameRegexFilter
--- PASS: TestAccOvirtVNicProfilesDataSource_nameRegexFilter (2.40s)
PASS
ok      github.com/EMSL-MSC/terraform-provider-ovirt/ovirt      2.406s
steki@pc:~/go/src/github.com/EMSL-MSC/terraform-provider-ovirt> 
```
