### PR TITLE
resource/ovirt_vm: Redesign the disks and vnics of VM resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,15 @@ provider "ovirt" {
   * ovirt_disk_attachment
   * ovirt_datacenter
   * ovirt_network
+  * ovirt_vnic
   * ovirt_vnic_profile
 * Data Sources
   * ovirt_disks
   * ovirt_datacenters
   * ovirt_networks
   * ovirt_clusters
+  * ovirt_storagedomains
+  * ovirt_vnic_profiles
 
 
 Disclaimer

--- a/main.tf
+++ b/main.tf
@@ -32,28 +32,30 @@ resource "ovirt_vm" "my_vm_1" {
     }
   }
 
-  vnic {
-    name            = "nic1"
-    vnic_profile_id = "${ovirt_vnic_profile.vm_vnic_profile.id}"
-  }
+  # The `template_id` and `block_device` need to satisfy the following constraints:
+  #   1. One of them must be assgined
+  #   2. If the template speficified by `template_id` contains disks attached,
+  #      `block_device` can not be assigend
+  #   3. If the template speficified by `template_id` has no disks attached,
+  #      `block_device` must be assigned
 
-  vnic {
-    name            = "nic2"
-    vnic_profile_id = "${ovirt_vnic_profile.vm_vnic_profile.id}"
-  }
-
-  vnic {
-    name            = "nic3"
-    vnic_profile_id = "${ovirt_vnic_profile.vm_vnic_profile.id}"
-  }
-
-  attached_disk {
+  template_id = "00000000-0000-0000-0000-000000000000"
+  block_device {
     disk_id   = "${ovirt_disk.my_disk_1.id}"
-    bootable  = true
     interface = "virtio"
   }
+}
 
-  template = "Blank"
+resource "ovirt_vnic" "nic1" {
+  name            = "nic1"
+  vm_id           = "${ovirt_vm.my_vm_1.id}"
+  vnic_profile_id = "${ovirt_vnic_profile.vm_vnic_profile.id}"
+}
+
+resource "ovirt_vnic" "nic2" {
+  name            = "nic2"
+  vm_id           = "${ovirt_vm.my_vm_1.id}"
+  vnic_profile_id = "${ovirt_vnic_profile.vm_vnic_profile.id}"
 }
 
 resource "ovirt_disk" "my_disk_1" {

--- a/ovirt/provider.go
+++ b/ovirt/provider.go
@@ -46,6 +46,7 @@ func Provider() terraform.ResourceProvider {
 			"ovirt_disk_attachment": resourceOvirtDiskAttachment(),
 			"ovirt_datacenter":      resourceOvirtDataCenter(),
 			"ovirt_network":         resourceOvirtNetwork(),
+			"ovirt_vnic":            resourceOvirtVnic(),
 			"ovirt_vnic_profile":    resourceOvirtVnicProfile(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{

--- a/ovirt/resource_ovirt_vnic.go
+++ b/ovirt/resource_ovirt_vnic.go
@@ -1,0 +1,144 @@
+// Copyright (C) 2018 Joey Ma <majunjiev@gmail.com>
+// All rights reserved.
+//
+// This software may be modified and distributed under the terms
+// of the BSD-2 license.  See the LICENSE file for details.
+
+package ovirt
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+)
+
+func resourceOvirtVnic() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceOvirtVnicCreate,
+		Read:   resourceOvirtVnicRead,
+		Delete: resourceOvirtVnicDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"vm_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"vnic_profile_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceOvirtVnicCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+	vmService := conn.SystemService().
+		VmsService().
+		VmService(d.Get("vm_id").(string))
+
+	addVnicResp, err := vmService.NicsService().
+		Add().
+		Nic(
+			ovirtsdk4.NewNicBuilder().
+				Name(d.Get("name").(string)).
+				VnicProfile(
+					ovirtsdk4.NewVnicProfileBuilder().
+						Id(d.Get("vnic_profile_id").(string)).
+						MustBuild()).
+				MustBuild()).
+		Send()
+	if err != nil {
+		return err
+	}
+	vnic, ok := addVnicResp.Nic()
+	if !ok {
+		return fmt.Errorf("failed to add nic: response not contains the nic")
+	}
+
+	// The vnic could not be fetched via the vnic ID alone.
+	d.SetId(d.Get("vm_id").(string) + ":" + vnic.MustId())
+	return resourceOvirtVnicRead(d, meta)
+}
+
+func resourceOvirtVnicRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+	vmID, vnicID, err := getVMIDAndNicID(d.Id())
+	if err != nil {
+		return err
+	}
+	d.Set("vm_id", vmID)
+
+	getVnicResp, err := conn.SystemService().
+		VmsService().
+		VmService(vmID).
+		NicsService().
+		NicService(vnicID).
+		Get().
+		Send()
+	if err != nil {
+		if _, ok := err.(*ovirtsdk4.NotFoundError); ok {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.Set("name", getVnicResp.MustNic().MustName())
+	d.Set("vnic_profile_id", getVnicResp.MustNic().MustVnicProfile().MustId())
+
+	return nil
+}
+
+func resourceOvirtVnicDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+	vmID, vnicID, err := getVMIDAndNicID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	nicService := conn.SystemService().
+		VmsService().
+		VmService(vmID).
+		NicsService().
+		NicService(vnicID)
+
+	log.Printf("[DEBUG] Deactivate nic (%s) before remove", vnicID)
+	_, err = nicService.Deactivate().Send()
+	if err != nil {
+		if _, ok := err.(*ovirtsdk4.NotFoundError); ok {
+			return nil
+		}
+		return err
+	}
+
+	log.Printf("[DEBUG] Now to remove nic (%s) ", vnicID)
+	_, err = nicService.Remove().Send()
+	if err != nil {
+		if _, ok := err.(*ovirtsdk4.NotFoundError); ok {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func getVMIDAndNicID(id string) (string, string, error) {
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("Invalid resource id")
+	}
+	return parts[0], parts[1], nil
+}


### PR DESCRIPTION
For issue #52 .

Changes proposed in this pull request:

* Add a new resource: `ovirt_vnic` and remove `vnic` attribute definition from `ovirt_vm`
> The new resource represents the nics which are explicitly attached to a VM by configurations.
* Use `block_device` attribute instead of `attached_disk` in resource`ovirt_vm`
> The new attribute represents the only bootable disk attached to this VM. It has the type of `List` and limited to one item at most. Noted that the disk described by this attribute in backend is **NOT** managed by Terraform. If you want to manage disks attached in more depth, please use resource `ovirt_disk_attachment`.
* Replace `template` with `template_id` in resource `ovirt_vm`

Basically, since the disks and nics of VM based on a template are implicitly created, this pull request makes them get rid of the control of Terraform. Terraform will still assume management of the ones explicitly indicated by `ovirt_disk_attachment` and `ovirt_vnic`.

See the new `main.tf` for detailed usage.


Output from acceptance testing:

```
$ make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtVM_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtVM_ -timeout 180m
=== RUN   TestAccOvirtVM_blockDevice
--- PASS: TestAccOvirtVM_blockDevice (198.40s)
=== RUN   TestAccOvirtVM_template
--- PASS: TestAccOvirtVM_template (175.50s)
=== RUN   TestAccOvirtVM_vnic
--- PASS: TestAccOvirtVM_vnic (94.71s)
PASS
ok  	github.com/EMSL-MSC/terraform-provider-ovirt/ovirt	468.633s
```
